### PR TITLE
PR #4: R-SKY-002 Hemisphere Stitcher

### DIFF
--- a/packages/sky-detection/__tests__/hemisphere-stitcher.test.ts
+++ b/packages/sky-detection/__tests__/hemisphere-stitcher.test.ts
@@ -560,5 +560,50 @@ describe('R-SKY-002: Hemisphere Stitcher', () => {
       expect(updatedMask.metadata.lastUpdated).not.toBeNull();
       expect(updatedMask.metadata.lastUpdated!.getTime()).toBeGreaterThanOrEqual(beforeTime.getTime());
     });
+
+    it('should throw for mismatched pixel grid dimensions (rows)', () => {
+      const mask = createEmptySkyMask(logger);
+      
+      const frame = createScanFrame({
+        deviceAzimuth: 0,
+        deviceElevation: 0,
+        deviceRoll: 0,
+        fieldOfViewH: 60,
+        fieldOfViewV: 60,
+        pixelClassifications: {
+          width: 2,
+          height: 3, // Says 3 rows
+          data: [
+            [ObstructionType.Sky, ObstructionType.Sky],
+            [ObstructionType.Sky, ObstructionType.Sky]
+            // Only 2 rows provided
+          ]
+        }
+      });
+
+      expect(() => stitchFrame(mask, frame, logger)).toThrow('row count');
+    });
+
+    it('should throw for mismatched pixel grid dimensions (columns)', () => {
+      const mask = createEmptySkyMask(logger);
+      
+      const frame = createScanFrame({
+        deviceAzimuth: 0,
+        deviceElevation: 0,
+        deviceRoll: 0,
+        fieldOfViewH: 60,
+        fieldOfViewV: 60,
+        pixelClassifications: {
+          width: 3, // Says 3 columns
+          height: 2,
+          data: [
+            [ObstructionType.Sky, ObstructionType.Sky], // Only 2 columns
+            [ObstructionType.Sky, ObstructionType.Sky]
+          ]
+        }
+      });
+
+      expect(() => stitchFrame(mask, frame, logger)).toThrow('column count');
+    });
   });
 });

--- a/packages/sky-detection/src/hemisphere-stitcher.ts
+++ b/packages/sky-detection/src/hemisphere-stitcher.ts
@@ -249,6 +249,20 @@ export function stitchFrame(
 
   const { width, height, data } = frame.pixelClassifications;
 
+  // Validate pixel grid dimensions
+  if (data.length !== height) {
+    throw new Error(
+      `Pixel grid row count (${data.length}) doesn't match height (${height})`
+    );
+  }
+  for (let y = 0; y < height; y++) {
+    if (data[y].length !== width) {
+      throw new Error(
+        `Pixel grid column count (${data[y].length}) at row ${y} doesn't match width (${width})`
+      );
+    }
+  }
+
   // Process each pixel in the grid
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {


### PR DESCRIPTION
Hemisphere stitcher for projecting camera frames onto spherical sky mask.

Depends on #3

## Changes
- pixelToSpherical() with roll rotation support
- calculatePixelAngularSize() for FOV math
- stitchFrame() for single frame projection
- stitchFrames() for batch processing
- Confidence weighting (center pixels higher)
- Last-write-wins merge strategy
- 20 comprehensive tests

## Stack
- ✅ PR #1 - Monorepo Scaffold
- ✅ PR #2 - Core Package
- ✅ PR #3 - Sky Mask Data Structure
- ⬜ This PR (#4) - Hemisphere Stitcher
- ⬜ PR #5 - AR/UI/Mobile Scaffolds