### PR TITLE
PR #7: R-SKY-004 Sky Classifier Interface

### DIFF
--- a/packages/sky-detection/__tests__/sky-classifier.test.ts
+++ b/packages/sky-detection/__tests__/sky-classifier.test.ts
@@ -1,0 +1,259 @@
+/**
+ * @module @sunscope/sky-detection/__tests__/sky-classifier
+ * @description Tests for sky classifier interface (R-SKY-004)
+ * 
+ * Acceptance Criteria:
+ * - SkyClassifier interface defines classifyFrame method
+ * - MockSkyClassifier returns predetermined classifications for testing
+ * - DeepLabV3Classifier stub exists for future native implementation
+ * - PixelGrid output matches input dimensions
+ * - Classifications are valid ObstructionType values
+ */
+
+import {
+  SkyClassifier,
+  MockSkyClassifier,
+  DeepLabV3Classifier,
+  createPixelGrid
+} from '../src/sky-classifier';
+
+import { ObstructionType } from '../src/types';
+import { TestLogger } from '@sunscope/core';
+
+describe('R-SKY-004: Sky Classifier Interface', () => {
+  let logger: TestLogger;
+
+  beforeEach(() => {
+    logger = new TestLogger('sky-classifier-test');
+  });
+
+  afterEach(() => {
+    logger.clear();
+  });
+
+  describe('createPixelGrid', () => {
+    it('should create empty pixel grid with correct dimensions', () => {
+      const grid = createPixelGrid(64, 48);
+      
+      expect(grid.width).toBe(64);
+      expect(grid.height).toBe(48);
+      expect(grid.data).toHaveLength(48); // rows
+      expect(grid.data[0]).toHaveLength(64); // columns
+    });
+
+    it('should initialize all pixels to Unknown', () => {
+      const grid = createPixelGrid(4, 4);
+      
+      for (let y = 0; y < 4; y++) {
+        for (let x = 0; x < 4; x++) {
+          expect(grid.data[y][x]).toBe(ObstructionType.Unknown);
+        }
+      }
+    });
+
+    it('should throw for invalid dimensions', () => {
+      expect(() => createPixelGrid(0, 64)).toThrow();
+      expect(() => createPixelGrid(64, 0)).toThrow();
+      expect(() => createPixelGrid(-1, 64)).toThrow();
+    });
+  });
+
+  describe('MockSkyClassifier', () => {
+    it('should return predetermined classification', async () => {
+      const classifier = new MockSkyClassifier({
+        defaultType: ObstructionType.Sky
+      });
+
+      const imageData = new Uint8Array(64 * 64 * 4); // RGBA
+      const result = await classifier.classifyFrame(imageData, 64, 64, logger);
+
+      expect(result.width).toBe(64);
+      expect(result.height).toBe(64);
+      
+      // All pixels should be Sky
+      expect(result.data[0][0]).toBe(ObstructionType.Sky);
+      expect(result.data[32][32]).toBe(ObstructionType.Sky);
+    });
+
+    it('should support different default types', async () => {
+      const classifier = new MockSkyClassifier({
+        defaultType: ObstructionType.Building
+      });
+
+      const imageData = new Uint8Array(32 * 32 * 4);
+      const result = await classifier.classifyFrame(imageData, 32, 32, logger);
+
+      expect(result.data[0][0]).toBe(ObstructionType.Building);
+    });
+
+    it('should simulate processing delay', async () => {
+      const classifier = new MockSkyClassifier({
+        defaultType: ObstructionType.Sky,
+        delayMs: 50
+      });
+
+      const start = Date.now();
+      const imageData = new Uint8Array(64 * 64 * 4);
+      await classifier.classifyFrame(imageData, 64, 64, logger);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeGreaterThanOrEqual(50);
+    });
+
+    it('should log classification', async () => {
+      const classifier = new MockSkyClassifier({
+        defaultType: ObstructionType.Tree
+      });
+
+      const imageData = new Uint8Array(64 * 64 * 4);
+      await classifier.classifyFrame(imageData, 64, 64, logger);
+
+      expect(logger.hasEntry(e => e.message.includes('Mock classification'))).toBe(true);
+    });
+
+    it('should support vertical split pattern', async () => {
+      const classifier = new MockSkyClassifier({
+        pattern: 'vertical-split',
+        leftType: ObstructionType.Sky,
+        rightType: ObstructionType.Building
+      });
+
+      const imageData = new Uint8Array(64 * 64 * 4);
+      const result = await classifier.classifyFrame(imageData, 64, 64, logger);
+
+      // Left half should be Sky
+      expect(result.data[32][15]).toBe(ObstructionType.Sky);
+      // Right half should be Building
+      expect(result.data[32][48]).toBe(ObstructionType.Building);
+    });
+
+    it('should support horizontal split pattern', async () => {
+      const classifier = new MockSkyClassifier({
+        pattern: 'horizontal-split',
+        topType: ObstructionType.Sky,
+        bottomType: ObstructionType.Tree
+      });
+
+      const imageData = new Uint8Array(64 * 64 * 4);
+      const result = await classifier.classifyFrame(imageData, 64, 64, logger);
+
+      // Top half should be Sky
+      expect(result.data[15][32]).toBe(ObstructionType.Sky);
+      // Bottom half should be Tree
+      expect(result.data[48][32]).toBe(ObstructionType.Tree);
+    });
+
+    it('should support noise pattern', async () => {
+      const classifier = new MockSkyClassifier({
+        pattern: 'noise',
+        noiseTypes: [ObstructionType.Sky, ObstructionType.Tree]
+      });
+
+      const imageData = new Uint8Array(64 * 64 * 4);
+      const result = await classifier.classifyFrame(imageData, 64, 64, logger);
+
+      // Should have mix of types
+      const types = new Set<ObstructionType>();
+      for (let y = 0; y < 64; y++) {
+        for (let x = 0; x < 64; x++) {
+          types.add(result.data[y][x]);
+        }
+      }
+      
+      expect(types.size).toBeGreaterThan(1);
+    });
+  });
+
+  describe('DeepLabV3Classifier', () => {
+    it('should be defined as stub', () => {
+      expect(DeepLabV3Classifier).toBeDefined();
+    });
+
+    it('should throw not implemented error', async () => {
+      const classifier = new DeepLabV3Classifier();
+      const imageData = new Uint8Array(64 * 64 * 4);
+
+      await expect(
+        classifier.classifyFrame(imageData, 64, 64, logger)
+      ).rejects.toThrow('not implemented');
+    });
+
+    it('should log initialization', () => {
+      new DeepLabV3Classifier(logger);
+      
+      expect(logger.hasEntry(e => e.message.includes('DeepLabV3 classifier stub'))).toBe(true);
+    });
+  });
+
+  describe('interface compliance', () => {
+    it('MockSkyClassifier implements SkyClassifier', async () => {
+      const classifier: SkyClassifier = new MockSkyClassifier({
+        defaultType: ObstructionType.Sky
+      });
+
+      const imageData = new Uint8Array(32 * 32 * 4);
+      const result = await classifier.classifyFrame(imageData, 32, 32, logger);
+
+      expect(result).toBeDefined();
+      expect(result.width).toBe(32);
+      expect(result.height).toBe(32);
+    });
+
+    it('DeepLabV3Classifier is defined', () => {
+      expect(DeepLabV3Classifier).toBeDefined();
+    });
+
+    it('should handle empty image data', async () => {
+      const classifier = new MockSkyClassifier({
+        defaultType: ObstructionType.Sky
+      });
+
+      const imageData = new Uint8Array(0);
+      const result = await classifier.classifyFrame(imageData, 64, 64, logger);
+
+      expect(result.width).toBe(64);
+      expect(result.height).toBe(64);
+    });
+
+    it('should validate output dimensions match input', async () => {
+      const classifier = new MockSkyClassifier({
+        defaultType: ObstructionType.Sky
+      });
+
+      const imageData = new Uint8Array(100 * 50 * 4);
+      const result = await classifier.classifyFrame(imageData, 100, 50, logger);
+
+      expect(result.width).toBe(100);
+      expect(result.height).toBe(50);
+      expect(result.data).toHaveLength(50);
+      expect(result.data[0]).toHaveLength(100);
+    });
+  });
+
+  describe('classification validation', () => {
+    it('should only return valid ObstructionType values', async () => {
+      const classifier = new MockSkyClassifier({
+        pattern: 'noise',
+        noiseTypes: [
+          ObstructionType.Sky,
+          ObstructionType.Tree,
+          ObstructionType.Building,
+          ObstructionType.Roof,
+          ObstructionType.Fence,
+          ObstructionType.Unknown
+        ]
+      });
+
+      const imageData = new Uint8Array(64 * 64 * 4);
+      const result = await classifier.classifyFrame(imageData, 64, 64, logger);
+
+      const validTypes = Object.values(ObstructionType);
+      
+      for (let y = 0; y < 64; y++) {
+        for (let x = 0; x < 64; x++) {
+          expect(validTypes).toContain(result.data[y][x]);
+        }
+      }
+    });
+  });
+});

--- a/packages/sky-detection/src/index.ts
+++ b/packages/sky-detection/src/index.ts
@@ -16,4 +16,4 @@ export * from './hemisphere-stitcher';
 export * from './arc-integrator';
 
 // Sky classifier (R-SKY-004)
-// export * from './sky-classifier';
+export * from './sky-classifier';

--- a/packages/sky-detection/src/sky-classifier.ts
+++ b/packages/sky-detection/src/sky-classifier.ts
@@ -1,0 +1,224 @@
+/**
+ * @module @sunscope/sky-detection/sky-classifier
+ * @description Sky classifier interface and implementations (R-SKY-004)
+ * 
+ * This module defines the SkyClassifier interface and provides implementations
+ * for testing and future native ML integration.
+ * 
+ * Dependencies: types.ts, logger.ts (from core)
+ * 
+ * Acceptance Criteria:
+ * - SkyClassifier interface defines classifyFrame method
+ * - MockSkyClassifier returns predetermined classifications for testing
+ * - DeepLabV3Classifier stub exists for future native implementation
+ * - PixelGrid output matches input dimensions
+ * - Classifications are valid ObstructionType values
+ */
+
+import { PixelGrid, ObstructionType, SkyClassifier as ISkyClassifier } from './types';
+import { ILogger } from '@sunscope/core';
+
+// Re-export interface from types
+export type { ISkyClassifier as SkyClassifier };
+
+/**
+ * Create an empty pixel grid with given dimensions
+ * @param width - Grid width in pixels
+ * @param height - Grid height in pixels
+ * @returns Empty pixel grid (all Unknown)
+ */
+export function createPixelGrid(width: number, height: number): PixelGrid {
+  if (width <= 0 || height <= 0) {
+    throw new Error(`Invalid dimensions: ${width}x${height}`);
+  }
+
+  const data: ObstructionType[][] = [];
+  
+  for (let y = 0; y < height; y++) {
+    const row: ObstructionType[] = [];
+    for (let x = 0; x < width; x++) {
+      row.push(ObstructionType.Unknown);
+    }
+    data.push(row);
+  }
+
+  return { width, height, data };
+}
+
+/**
+ * Options for MockSkyClassifier
+ */
+export interface MockClassifierOptions {
+  /** Default classification type for all pixels */
+  defaultType?: ObstructionType;
+  /** Pattern to generate: 'uniform' | 'vertical-split' | 'horizontal-split' | 'noise' */
+  pattern?: 'uniform' | 'vertical-split' | 'horizontal-split' | 'noise';
+  /** Type for left half (vertical-split) or top half (horizontal-split) */
+  leftType?: ObstructionType;
+  topType?: ObstructionType;
+  /** Type for right half (vertical-split) or bottom half (horizontal-split) */
+  rightType?: ObstructionType;
+  bottomType?: ObstructionType;
+  /** Types to use for noise pattern */
+  noiseTypes?: ObstructionType[];
+  /** Simulated processing delay in ms */
+  delayMs?: number;
+}
+
+/**
+ * Mock sky classifier for testing
+ * 
+ * Returns predetermined classifications based on configuration.
+ * Useful for unit testing without native dependencies.
+ */
+export class MockSkyClassifier implements ISkyClassifier {
+  private options: Required<MockClassifierOptions>;
+
+  constructor(options: MockClassifierOptions = {}) {
+    this.options = {
+      defaultType: options.defaultType ?? ObstructionType.Sky,
+      pattern: options.pattern ?? 'uniform',
+      leftType: options.leftType ?? ObstructionType.Sky,
+      topType: options.topType ?? ObstructionType.Sky,
+      rightType: options.rightType ?? ObstructionType.Building,
+      bottomType: options.bottomType ?? ObstructionType.Tree,
+      noiseTypes: options.noiseTypes ?? [ObstructionType.Sky, ObstructionType.Tree],
+      delayMs: options.delayMs ?? 0
+    };
+  }
+
+  async classifyFrame(
+    _imageData: Uint8Array,
+    width: number,
+    height: number,
+    logger?: ILogger
+  ): Promise<PixelGrid> {
+    const startTime = Date.now();
+
+    // Simulate processing delay
+    if (this.options.delayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, this.options.delayMs));
+    }
+
+    const grid = createPixelGrid(width, height);
+
+    // Fill based on pattern
+    switch (this.options.pattern) {
+      case 'uniform':
+        this.fillUniform(grid);
+        break;
+      case 'vertical-split':
+        this.fillVerticalSplit(grid);
+        break;
+      case 'horizontal-split':
+        this.fillHorizontalSplit(grid);
+        break;
+      case 'noise':
+        this.fillNoise(grid);
+        break;
+    }
+
+    const elapsedMs = Date.now() - startTime;
+
+    logger?.debug('Mock classification complete', {
+      width,
+      height,
+      pattern: this.options.pattern,
+      defaultType: this.options.defaultType,
+      elapsedMs
+    });
+
+    return grid;
+  }
+
+  private fillUniform(grid: PixelGrid): void {
+    for (let y = 0; y < grid.height; y++) {
+      for (let x = 0; x < grid.width; x++) {
+        grid.data[y][x] = this.options.defaultType;
+      }
+    }
+  }
+
+  private fillVerticalSplit(grid: PixelGrid): void {
+    const midX = Math.floor(grid.width / 2);
+    
+    for (let y = 0; y < grid.height; y++) {
+      for (let x = 0; x < grid.width; x++) {
+        grid.data[y][x] = x < midX ? this.options.leftType : this.options.rightType;
+      }
+    }
+  }
+
+  private fillHorizontalSplit(grid: PixelGrid): void {
+    const midY = Math.floor(grid.height / 2);
+    
+    for (let y = 0; y < grid.height; y++) {
+      for (let x = 0; x < grid.width; x++) {
+        grid.data[y][x] = y < midY ? this.options.topType! : this.options.bottomType!;
+      }
+    }
+  }
+
+  private fillNoise(grid: PixelGrid): void {
+    const types = this.options.noiseTypes;
+    
+    for (let y = 0; y < grid.height; y++) {
+      for (let x = 0; x < grid.width; x++) {
+        // Simple noise based on position
+        const index = (x + y * grid.width) % types.length;
+        grid.data[y][x] = types[index];
+      }
+    }
+  }
+}
+
+/**
+ * DeepLabV3 classifier stub
+ * 
+ * Placeholder for future native implementation using CoreML/TensorFlow.
+ * This will be implemented when native module bridge is ready.
+ */
+export class DeepLabV3Classifier implements ISkyClassifier {
+
+
+  constructor(logger?: ILogger) {
+    logger?.info('DeepLabV3 classifier stub initialized', {
+      status: 'not-implemented'
+    });
+  }
+
+  async classifyFrame(
+    imageData: Uint8Array,
+    width: number,
+    height: number,
+    logger?: ILogger
+  ): Promise<PixelGrid> {
+    logger?.error('DeepLabV3 classification not implemented', {
+      width,
+      height,
+      imageDataLength: imageData.length
+    });
+
+    throw new Error(
+      'DeepLabV3 classifier not implemented. ' +
+      'Use MockSkyClassifier for testing. ' +
+      'Native implementation pending CoreML bridge.'
+    );
+  }
+
+  /**
+   * Check if native module is available
+   * Stub always returns false
+   */
+  isAvailable(): boolean {
+    return false;
+  }
+
+  /**
+   * Load model - stub implementation
+   */
+  async loadModel(logger?: ILogger): Promise<void> {
+    logger?.warn('Model loading not implemented in stub');
+    throw new Error('Model loading not implemented');
+  }
+}

--- a/packages/sky-detection/src/types.ts
+++ b/packages/sky-detection/src/types.ts
@@ -131,9 +131,10 @@ export interface SkyClassifier {
    * @param imageData - Raw image data (e.g., Uint8Array from camera)
    * @param width - Image width in pixels
    * @param height - Image height in pixels
+   * @param logger - Optional logger for debugging
    * @returns Promise resolving to pixel classifications
    */
-  classifyFrame(imageData: Uint8Array, width: number, height: number): Promise<PixelGrid>;
+  classifyFrame(imageData: Uint8Array, width: number, height: number, logger?: import('@sunscope/core').ILogger): Promise<PixelGrid>;
 }
 
 /**


### PR DESCRIPTION
Sky classifier interface and mock implementations.

Depends on #6

## Changes
- SkyClassifier interface with classifyFrame method
- MockSkyClassifier with patterns: uniform, vertical-split, horizontal-split, noise
- DeepLabV3Classifier stub for native ML
- createPixelGrid() helper
- 18 comprehensive tests

## Stack
- ✅ PR #1 - Monorepo Scaffold
- ✅ PR #2 - Core Package
- ✅ PR #3 - Sky Mask Data Structure
- ✅ PR #4 - Hemisphere Stitcher
- ✅ PR #5 - AR/UI/Mobile Scaffolds
- ✅ PR #6 - Arc Integrator
- ⬜ This PR (#7) - Sky Classifier Interface

**Phase 1 Complete** (R-SKY-001 through R-SKY-004)