### PR TITLE
Finish monorepo cleanup

### DIFF
--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
+    "jsx": "react-native",
     "strict": true,
     "types": ["jest", "node"]
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "test": "pnpm -r test",
+    "typecheck": "pnpm -r typecheck",
     "lint": "pnpm -r lint",
     "build": "pnpm -r build"
   },

--- a/packages/ar/package.json
+++ b/packages/ar/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "src/index.ts",
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "build": "tsc"
   },

--- a/packages/ar/tsconfig.json
+++ b/packages/ar/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
     "jsx": "react",
     "resolveJsonModule": true,
     "esModuleInterop": true

--- a/packages/core/__tests__/location-store.test.ts
+++ b/packages/core/__tests__/location-store.test.ts
@@ -62,7 +62,7 @@ describe('validateLocation', () => {
     expect(entry?.data).not.toHaveProperty('lon');
   });
 
-  it('logs validation errors without raw coordinate fields', () => {
+  it('logs validation errors without raw coordinate fields or values', () => {
     const l = new TestLogger();
     expect(() => validateLocation({ lat: 91, lon: 0 }, l)).toThrow(LocationValidationError);
     const entry = l.entries.find((e) => e.level === 'ERROR' && e.message.startsWith('Invalid latitude'));
@@ -70,6 +70,7 @@ describe('validateLocation', () => {
     expect(entry?.data).toEqual(expect.objectContaining({ coordinatesRedacted: true, axis: 'latitude' }));
     expect(entry?.data).not.toHaveProperty('lat');
     expect(entry?.data).not.toHaveProperty('lon');
+    expect(entry?.message).not.toContain('91');
   });
 });
 
@@ -123,22 +124,12 @@ describe('serializeLocation / deserializeLocation round-trip', () => {
 });
 
 describe('validateLocation — error messages', () => {
-  it('error message contains the invalid latitude value', () => {
-    try {
-      validateLocation({ lat: 100, lon: 0 });
-      fail('expected to throw');
-    } catch (e: any) {
-      expect(e.message).toContain('100');
-    }
+  it('latitude error message omits raw coordinate value', () => {
+    expect(() => validateLocation({ lat: 100, lon: 0 })).toThrow('Invalid latitude: must be in [-90, 90]');
   });
 
-  it('error message contains the invalid longitude value', () => {
-    try {
-      validateLocation({ lat: 0, lon: 200 });
-      fail('expected to throw');
-    } catch (e: any) {
-      expect(e.message).toContain('200');
-    }
+  it('longitude error message omits raw coordinate value', () => {
+    expect(() => validateLocation({ lat: 0, lon: 200 })).toThrow('Invalid longitude: must be in [-180, 180]');
   });
 
   it('error is instance of LocationValidationError', () => {

--- a/packages/core/__tests__/location-store.test.ts
+++ b/packages/core/__tests__/location-store.test.ts
@@ -55,7 +55,21 @@ describe('validateLocation', () => {
   it('logs validation debug entry on success', () => {
     const l = new TestLogger();
     validateLocation({ lat: 0, lon: 0 }, l);
-    expect(l.entries).toContainEqual(expect.objectContaining({ level: 'DEBUG' }));
+    const entry = l.entries.find((e) => e.level === 'DEBUG' && e.message === 'Location validated');
+    expect(entry).toBeDefined();
+    expect(entry?.data).toEqual(expect.objectContaining({ coordinatesRedacted: true }));
+    expect(entry?.data).not.toHaveProperty('lat');
+    expect(entry?.data).not.toHaveProperty('lon');
+  });
+
+  it('logs validation errors without raw coordinate fields', () => {
+    const l = new TestLogger();
+    expect(() => validateLocation({ lat: 91, lon: 0 }, l)).toThrow(LocationValidationError);
+    const entry = l.entries.find((e) => e.level === 'ERROR' && e.message.startsWith('Invalid latitude'));
+    expect(entry).toBeDefined();
+    expect(entry?.data).toEqual(expect.objectContaining({ coordinatesRedacted: true, axis: 'latitude' }));
+    expect(entry?.data).not.toHaveProperty('lat');
+    expect(entry?.data).not.toHaveProperty('lon');
   });
 });
 

--- a/packages/core/__tests__/solar-engine.test.ts
+++ b/packages/core/__tests__/solar-engine.test.ts
@@ -21,6 +21,7 @@
  */
 
 import { getSunPosition, getSunTimes } from '../src/solar-engine';
+import { TestLogger } from '../src/logger';
 
 const LAT = 36.3048;
 const LON = -86.5974;
@@ -179,6 +180,34 @@ describe('getSunTimes — field ordering invariants', () => {
   });
 });
 
+describe('getSunPosition / getSunTimes — logging privacy', () => {
+  it('redacts coordinates from getSunPosition logs', () => {
+    const log = new TestLogger('solar-engine');
+    getSunPosition(LAT, LON, new Date('2026-06-21T12:00:00Z'), log);
+    const entry = log.entries.find((e) => e.message === 'getSunPosition computed');
+    expect(entry).toBeDefined();
+    expect(entry?.data?.input).toEqual(expect.objectContaining({
+      date: '2026-06-21T12:00:00.000Z',
+      coordinatesRedacted: true,
+    }));
+    expect(entry?.data?.input).not.toHaveProperty('lat');
+    expect(entry?.data?.input).not.toHaveProperty('lon');
+  });
+
+  it('redacts coordinates from getSunTimes logs', () => {
+    const log = new TestLogger('solar-engine');
+    getSunTimes(LAT, LON, new Date('2026-06-21T12:00:00Z'), log);
+    const entry = log.entries.find((e) => e.message === 'getSunTimes computed');
+    expect(entry).toBeDefined();
+    expect(entry?.data?.input).toEqual(expect.objectContaining({
+      date: '2026-06-21T12:00:00.000Z',
+      coordinatesRedacted: true,
+    }));
+    expect(entry?.data?.input).not.toHaveProperty('lat');
+    expect(entry?.data?.input).not.toHaveProperty('lon');
+  });
+});
+
 describe('getSunPosition — other latitudes', () => {
   it('equator near March equinox: noon altitude ≈ 90°', () => {
     // At the equator on equinox, sun passes nearly overhead
@@ -196,4 +225,3 @@ describe('getSunPosition — other latitudes', () => {
     expect(az < 45 || az > 315).toBe(true);
   });
 });
-

--- a/packages/core/__tests__/sun-day-sampler.test.ts
+++ b/packages/core/__tests__/sun-day-sampler.test.ts
@@ -130,9 +130,16 @@ describe('sampleSunDay — logging', () => {
   it('logs completion info entry', () => {
     const log = new TestLogger();
     sampleSunDay(LAT, LON, new Date('2026-06-21T00:00:00Z'), { log });
-    expect(log.at('INFO')).toContainEqual(
-      expect.objectContaining({ message: 'sampleSunDay complete' })
-    );
+    const entry = log.at('INFO').find((e) => e.message === 'sampleSunDay complete');
+    expect(entry).toBeDefined();
+    expect(entry?.data).toEqual(expect.objectContaining({
+      day: '2026-06-21T00:00:00.000Z',
+      totalSamples: 288,
+      intervalMinutes: 5,
+      coordinatesRedacted: true,
+    }));
+    expect(entry?.data).not.toHaveProperty('lat');
+    expect(entry?.data).not.toHaveProperty('lon');
   });
 });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "main": "src/index.ts",
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "build": "tsc",
     "test": "jest"
   },

--- a/packages/core/src/location-store.ts
+++ b/packages/core/src/location-store.ts
@@ -37,12 +37,12 @@ export const DEFAULT_LOCATION: Location = {
  */
 export function validateLocation(loc: Location, log: Logger = new DefaultLogger('location-store')): Location {
   if (loc.lat < -90 || loc.lat > 90) {
-    const msg = `Invalid latitude ${loc.lat}: must be in [-90, 90]`;
+    const msg = 'Invalid latitude: must be in [-90, 90]';
     log.error(msg, { coordinatesRedacted: true, axis: 'latitude' });
     throw new LocationValidationError(msg);
   }
   if (loc.lon < -180 || loc.lon > 180) {
-    const msg = `Invalid longitude ${loc.lon}: must be in [-180, 180]`;
+    const msg = 'Invalid longitude: must be in [-180, 180]';
     log.error(msg, { coordinatesRedacted: true, axis: 'longitude' });
     throw new LocationValidationError(msg);
   }

--- a/packages/core/src/location-store.ts
+++ b/packages/core/src/location-store.ts
@@ -38,15 +38,15 @@ export const DEFAULT_LOCATION: Location = {
 export function validateLocation(loc: Location, log: Logger = new DefaultLogger('location-store')): Location {
   if (loc.lat < -90 || loc.lat > 90) {
     const msg = `Invalid latitude ${loc.lat}: must be in [-90, 90]`;
-    log.error(msg, { lat: loc.lat });
+    log.error(msg, { coordinatesRedacted: true, axis: 'latitude' });
     throw new LocationValidationError(msg);
   }
   if (loc.lon < -180 || loc.lon > 180) {
     const msg = `Invalid longitude ${loc.lon}: must be in [-180, 180]`;
-    log.error(msg, { lon: loc.lon });
+    log.error(msg, { coordinatesRedacted: true, axis: 'longitude' });
     throw new LocationValidationError(msg);
   }
-  log.debug('Location validated', { lat: loc.lat, lon: loc.lon });
+  log.debug('Location validated', { coordinatesRedacted: true });
   return loc;
 }
 

--- a/packages/core/src/solar-engine.ts
+++ b/packages/core/src/solar-engine.ts
@@ -3,6 +3,13 @@ import { Logger, DefaultLogger } from './logger';
 import { suncalcToCompass, radToDeg } from './solar-convert';
 import { SunPosition, SunTimes } from './core-types';
 
+function summarizeInput(date: Date): Record<string, unknown> {
+  return {
+    date: date.toISOString(),
+    coordinatesRedacted: true,
+  };
+}
+
 /**
  * Gets sun position at a given time and location using suncalc,
  * returning angles adhering to app conventions (degrees, north-origin).
@@ -27,7 +34,7 @@ export function getSunPosition(lat: number, lon: number, date: Date, log?: Logge
   };
 
   l.debug('getSunPosition computed', {
-    input: { lat, lon, date: date.toISOString() },
+    input: summarizeInput(date),
     rawOutput: { azimuth: rawPos.azimuth, altitude: rawPos.altitude },
     convertedOutput: result,
     elapsedMs: Date.now() - startMs
@@ -52,7 +59,7 @@ export function getSunTimes(lat: number, lon: number, date: Date, log?: Logger):
   const rawTimes = suncalc.getTimes(date, lat, lon);
   
   l.debug('getSunTimes computed', {
-    input: { lat, lon, date: date.toISOString() },
+    input: summarizeInput(date),
     elapsedMs: Date.now() - startMs
   });
   

--- a/packages/core/src/sun-day-sampler.ts
+++ b/packages/core/src/sun-day-sampler.ts
@@ -69,10 +69,10 @@ export function sampleSunDay(
 
   const elapsedMs = Date.now() - start;
   log.info('sampleSunDay complete', {
-    lat, lon,
     day: new Date(anchor).toISOString(),
     totalSamples: samples.length,
     intervalMinutes,
+    coordinatesRedacted: true,
     elapsedMs,
   });
 

--- a/packages/sky-detection/package.json
+++ b/packages/sky-detection/package.json
@@ -4,6 +4,7 @@
   "description": "Sky mask data structure and processing for SunScope",
   "main": "src/index.ts",
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "build": "tsc",
     "test": "jest",
     "lint": "eslint src/"


### PR DESCRIPTION
## Summary
- Added root and package-level typecheck scripts so the workspace can be validated consistently.
- Fixed mobile TypeScript config so App.tsx typechecks with JSX enabled.
- Removed the AR package rootDir blocker so its tests and workspace imports typecheck cleanly.
- Redacted raw coordinates from core logging in location-store, solar-engine, and sun-day-sampler.
- Added regression tests covering the redacted log payloads.

## Validation
- pnpm typecheck
- pnpm test
